### PR TITLE
Add @ prefix for Claude Code automatic file import

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -158,8 +158,8 @@ function activate(context) {
                         // Step 3d: Give user opportunity to rename the file
                         finalPath = await promptForFileRename(finalPath);
                         
-                        // Step 3e: Insert the file path into the active terminal
-                        activeTerminal.sendText(finalPath, false);
+                        // Step 3e: Insert the file path into the active terminal with @ prefix for Claude Code
+                        activeTerminal.sendText(`@${finalPath}`, false);
                         
                         // Step 3f: Show success notification with file details
                         showSuccessMessage(finalPath);


### PR DESCRIPTION
## Summary
This enhancement adds automatic @ prefix to pasted image paths, enabling Claude Code's automatic file import feature.

## Changes
- Modified `extension.js` line 162 to prepend @ symbol to file paths
- When images are pasted, paths like `/mnt/c/tmp/foo.png` become `@/mnt/c/tmp/foo.png`
- Claude Code automatically reads files when paths start with @

## Benefits
- Seamless integration with Claude Code's import syntax
- Maintains all existing functionality
- Aligns with the extension's stated purpose of supporting "Claude Code conversations"
- No breaking changes - purely additive enhancement

## Test Plan
- [x] Verified extension still pastes image paths correctly
- [x] Confirmed @ prefix is added to all pasted paths
- [x] Tested with both clipboard screenshots and copied image files
- [x] Verified WSL path conversion still works with @ prefix