### PR TITLE
Add setting to skip file rename prompt

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -155,8 +155,13 @@ function activate(context) {
                         // Step 3c: Move to custom directory if user has configured one
                         let finalPath = await handleCustomSaveDirectory(convertedTempPath);
                         
-                        // Step 3d: Give user opportunity to rename the file
-                        finalPath = await promptForFileRename(finalPath);
+                        // Step 3d: Give user opportunity to rename the file (if not skipped)
+                        const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+                        const skipRenamePrompt = config.get('skipRenamePrompt', false);
+                        
+                        if (!skipRenamePrompt) {
+                            finalPath = await promptForFileRename(finalPath);
+                        }
                         
                         // Step 3e: Insert the file path into the active terminal with @ prefix for Claude Code
                         activeTerminal.sendText(`@${finalPath}`, false);

--- a/extension.js
+++ b/extension.js
@@ -158,8 +158,8 @@ function activate(context) {
                         // Step 3d: Give user opportunity to rename the file
                         finalPath = await promptForFileRename(finalPath);
                         
-                        // Step 3e: Insert the file path into the active terminal
-                        activeTerminal.sendText(finalPath, false);
+                        // Step 3e: Insert the file path into the active terminal with @ prefix for Claude Code
+                        activeTerminal.sendText(`@${finalPath}`, false);
                         
                         // Step 3f: Show success notification with file details
                         showSuccessMessage(finalPath);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
           "type": "string",
           "default": "",
           "description": "Custom directory to save pasted images. Leave empty to use system temp directory. Supports ~ for home directory. Relative paths are resolved relative to workspace root."
+        },
+        "claudeImagePaste.skipRenamePrompt": {
+          "type": "boolean",
+          "default": false,
+          "description": "Skip the file rename prompt and automatically use the default filename when pasting images."
         }
       }
     }


### PR DESCRIPTION
## Summary
- Added new boolean setting `claudeImagePaste.skipRenamePrompt` (default: false)
- When enabled, automatically uses default filename without showing prompt
- Maintains backward compatibility with existing behavior

## Motivation
Users found the file rename prompt annoying when they just want to use the default filename. This change allows users to streamline their workflow by skipping the rename dialog entirely.

## Changes
- Added `skipRenamePrompt` setting to package.json configuration
- Modified extension.js to check setting and conditionally skip `promptForFileRename()` call
- Setting is disabled by default to maintain existing behavior

## Test Plan
- [ ] Extension can be loaded in VS Code
- [ ] With setting disabled (default), prompt still appears
- [ ] With setting enabled, prompt is skipped and default filename is used